### PR TITLE
Fix: API 인증 및 응답 구조 개선, UserType enum 변경

### DIFF
--- a/migrations/1755321022215-UpdateUserTypeEnum.ts
+++ b/migrations/1755321022215-UpdateUserTypeEnum.ts
@@ -1,0 +1,83 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateUserTypeEnum1755321022215 implements MigrationInterface {
+  name = 'UpdateUserTypeEnum1755321022215';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Step 1: Add temporary text column
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD COLUMN "userType_temp" TEXT`,
+    );
+
+    // Step 2: Copy data and convert PROFESSIONAL to EXPERT
+    await queryRunner.query(
+      `UPDATE "users" SET "userType_temp" = CASE WHEN "userType" = 'PROFESSIONAL' THEN 'EXPERT' ELSE "userType"::text END`,
+    );
+
+    // Step 3: Drop the original column
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "userType"`);
+
+    // Step 4: Create new enum type with EXPERT instead of PROFESSIONAL
+    await queryRunner.query(
+      `CREATE TYPE "public"."users_usertype_enum_new" AS ENUM('HOBBY', 'EXPERT', 'ADMIN')`,
+    );
+
+    // Step 5: Add new column with new enum type
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD COLUMN "userType" "public"."users_usertype_enum_new" DEFAULT 'HOBBY'`,
+    );
+
+    // Step 6: Copy data from temp column to new enum column
+    await queryRunner.query(
+      `UPDATE "users" SET "userType" = "userType_temp"::"public"."users_usertype_enum_new"`,
+    );
+
+    // Step 7: Drop temporary column
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "userType_temp"`);
+
+    // Step 8: Drop old enum type and rename new one
+    await queryRunner.query(`DROP TYPE "public"."users_usertype_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."users_usertype_enum_new" RENAME TO "users_usertype_enum"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Step 1: Add temporary text column
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD COLUMN "userType_temp" TEXT`,
+    );
+
+    // Step 2: Copy data and convert EXPERT to PROFESSIONAL
+    await queryRunner.query(
+      `UPDATE "users" SET "userType_temp" = CASE WHEN "userType" = 'EXPERT' THEN 'PROFESSIONAL' ELSE "userType"::text END`,
+    );
+
+    // Step 3: Drop the current column
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "userType"`);
+
+    // Step 4: Create old enum type with PROFESSIONAL
+    await queryRunner.query(
+      `CREATE TYPE "public"."users_usertype_enum_old" AS ENUM('HOBBY', 'PROFESSIONAL', 'ADMIN')`,
+    );
+
+    // Step 5: Add column with old enum type
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD COLUMN "userType" "public"."users_usertype_enum_old" DEFAULT 'HOBBY'`,
+    );
+
+    // Step 6: Copy data from temp column to enum column
+    await queryRunner.query(
+      `UPDATE "users" SET "userType" = "userType_temp"::"public"."users_usertype_enum_old"`,
+    );
+
+    // Step 7: Drop temporary column
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "userType_temp"`);
+
+    // Step 8: Drop new enum type and rename old one
+    await queryRunner.query(`DROP TYPE "public"."users_usertype_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."users_usertype_enum_old" RENAME TO "users_usertype_enum"`,
+    );
+  }
+}

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Comment } from './entities/comment.entity';
@@ -6,7 +10,10 @@ import { Post } from '../posts/entities/post.entity';
 import { User } from '../users/entities/user.entity';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
-import { CommentResponseDto, CommentListResponseDto } from './dto/comment-response.dto';
+import {
+  CommentResponseDto,
+  CommentListResponseDto,
+} from './dto/comment-response.dto';
 
 @Injectable()
 export class CommentsService {
@@ -57,7 +64,9 @@ export class CommentsService {
       .orderBy('comment.createdAt', 'DESC')
       .getManyAndCount();
 
-    const commentResponses = comments.map(comment => this.transformToResponseDto(comment));
+    const commentResponses = comments.map((comment) =>
+      this.transformToResponseDto(comment),
+    );
 
     return {
       comments: commentResponses,
@@ -118,7 +127,11 @@ export class CommentsService {
     }
 
     // 게시글의 댓글 수 감소
-    await this.postsRepository.decrement({ id: comment.post.id }, 'commentCount', 1);
+    await this.postsRepository.decrement(
+      { id: comment.post.id },
+      'commentCount',
+      1,
+    );
 
     await this.commentsRepository.remove(comment);
   }

--- a/src/configs/typeorm-cli.config.ts
+++ b/src/configs/typeorm-cli.config.ts
@@ -10,6 +10,7 @@ import { Comment } from '../comments/entities/comment.entity';
 import { PostLike } from '../posts/entities/post-like.entity';
 import { Tag } from '../tags/entities/tag.entity';
 import { PostTag } from '../posts/entities/post-tag.entity';
+import { Reservation } from '../reservations/entities/reservation.entity';
 
 // 환경변수 로드
 config();
@@ -44,6 +45,7 @@ const AppDataSource = new DataSource({
     PostLike,
     Tag,
     PostTag,
+    Reservation,
     // 추가 경로 방식 (필요시 사용)
     // join(__dirname, '../**/*.entity{.ts,.js}')
   ],

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -269,6 +269,66 @@ export class PostsController {
     };
   }
 
+  @Get(':id/like')
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @ApiOperation({
+    summary: '게시글 좋아요 상태 조회',
+    description: `게시글의 좋아요 수와 현재 사용자의 좋아요 여부를 조회합니다.
+
+📊 반환 정보:
+• likeCount: 총 좋아요 수
+• isLiked: 현재 사용자의 좋아요 여부 (로그인 필수)
+
+💡 활용 예시:
+• 게시글 목록에서 좋아요 수 표시
+• 좋아요 버튼 상태 (빨간색/회색) 결정
+• 실시간 좋아요 카운트 업데이트`,
+  })
+  @ApiParam({
+    name: 'id',
+    description: '조회할 게시글 ID',
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '좋아요 상태 조회 성공',
+    schema: {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean', example: true },
+        message: {
+          type: 'string',
+          example: '좋아요 상태를 조회했습니다.',
+        },
+        data: {
+          type: 'object',
+          properties: {
+            likeCount: {
+              type: 'number',
+              example: 15,
+              description: '총 좋아요 수',
+            },
+            isLiked: {
+              type: 'boolean',
+              example: true,
+              description:
+                '현재 사용자의 좋아요 여부 (로그인 시에만 true/false, 비로그인 시 false)',
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
+  @ApiResponse({ status: 404, description: '게시글을 찾을 수 없음' })
+  async getLikeStatus(
+    @Param('id', ParseIntPipe) id: number,
+    @GetUser('id') userId: number,
+  ): Promise<{ likeCount: number; isLiked: boolean }> {
+    return await this.postsService.getLikeStatus(id, userId);
+  }
+
   @Post(':id/like')
   @ApiBearerAuth()
   @UseGuards(AuthGuard('jwt'))

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -69,7 +69,7 @@ export class PostsService {
   ): Promise<PostResponseDto> {
     const user = await this.getUserById(userId);
 
-    if (user.userType !== UserType.PROFESSIONAL) {
+    if (user.userType !== UserType.EXPERT) {
       throw new ForbiddenException(
         '전문농업인만 예약 게시글을 작성할 수 있습니다.',
       );
@@ -248,6 +248,33 @@ export class PostsService {
     }
 
     return await this.findOneById(postId, userId);
+  }
+
+  async getLikeStatus(
+    postId: number,
+    userId: number,
+  ): Promise<{
+    likeCount: number;
+    isLiked: boolean;
+  }> {
+    const post = await this.postsRepository.findOne({
+      where: { id: postId },
+      select: ['id', 'likeCount'],
+    });
+
+    if (!post) {
+      throw new NotFoundException(`ID ${postId}번 게시글을 찾을 수 없습니다.`);
+    }
+
+    const like = await this.postLikesRepository.findOne({
+      where: { post: { id: postId }, user: { id: userId } },
+    });
+    const isLiked = !!like;
+
+    return {
+      likeCount: post.likeCount,
+      isLiked,
+    };
   }
 
   private buildBaseQuery(): SelectQueryBuilder<Post> {

--- a/src/reservations/reservations.controller.ts
+++ b/src/reservations/reservations.controller.ts
@@ -55,12 +55,17 @@ export class ReservationsController {
     @Param('postId', ParseIntPipe) postId: number,
     @Body() createReservationDto: CreateReservationDto,
     @GetUser('id') userId: number,
-  ) {
-    return await this.reservationsService.create(
+  ): Promise<ApiResponseDto<Reservation>> {
+    const data = await this.reservationsService.create(
       postId,
       userId,
       createReservationDto,
     );
+    return {
+      success: true,
+      message: '예약 신청이 성공적으로 완료되었습니다.',
+      data,
+    };
   }
 
   @Get('my')
@@ -74,8 +79,15 @@ export class ReservationsController {
     type: ApiResponseDto<Reservation[]>,
   })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
-  async findMyReservations(@GetUser('id') userId: number) {
-    return await this.reservationsService.findMyReservations(userId);
+  async findMyReservations(
+    @GetUser('id') userId: number,
+  ): Promise<ApiResponseDto<Reservation[]>> {
+    const data = await this.reservationsService.findMyReservations(userId);
+    return {
+      success: true,
+      message: '예약 목록을 성공적으로 조회했습니다.',
+      data,
+    };
   }
 
   @Get('received')
@@ -89,8 +101,16 @@ export class ReservationsController {
     type: ApiResponseDto<Reservation[]>,
   })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
-  async findReceivedReservations(@GetUser('id') userId: number) {
-    return await this.reservationsService.findReceivedReservations(userId);
+  async findReceivedReservations(
+    @GetUser('id') userId: number,
+  ): Promise<ApiResponseDto<Reservation[]>> {
+    const data =
+      await this.reservationsService.findReceivedReservations(userId);
+    return {
+      success: true,
+      message: '받은 예약 목록을 성공적으로 조회했습니다.',
+      data,
+    };
   }
 
   @Patch(':id/status')
@@ -117,12 +137,17 @@ export class ReservationsController {
     @Param('id', ParseIntPipe) id: number,
     @Body() updateReservationStatusDto: UpdateReservationStatusDto,
     @GetUser('id') userId: number,
-  ) {
-    return await this.reservationsService.updateStatus(
+  ): Promise<ApiResponseDto<Reservation>> {
+    const data = await this.reservationsService.updateStatus(
       id,
       userId,
       updateReservationStatusDto,
     );
+    return {
+      success: true,
+      message: '예약 상태가 성공적으로 변경되었습니다.',
+      data,
+    };
   }
 
   @Patch(':id/cancel')
@@ -148,7 +173,16 @@ export class ReservationsController {
     @Param('id', ParseIntPipe) id: number,
     @Body('cancelReason') cancelReason: string,
     @GetUser('id') userId: number,
-  ) {
-    return await this.reservationsService.cancel(id, userId, cancelReason);
+  ): Promise<ApiResponseDto<Reservation>> {
+    const data = await this.reservationsService.cancel(
+      id,
+      userId,
+      cancelReason,
+    );
+    return {
+      success: true,
+      message: '예약이 성공적으로 취소되었습니다.',
+      data,
+    };
   }
 }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -59,7 +59,7 @@ export class CreateUserDto {
   @ApiProperty({
     enum: UserType,
     example: UserType.HOBBY,
-    description: '사용자 유형 (HOBBY, PROFESSIONAL, ADMIN)',
+    description: '사용자 유형 (HOBBY, EXPERT, ADMIN)',
     required: false,
   })
   @IsEnum(UserType, {

--- a/src/users/dto/profile-update.dto.ts
+++ b/src/users/dto/profile-update.dto.ts
@@ -40,11 +40,11 @@ export class ProfileUpdateDto {
 
   @ApiPropertyOptional({
     enum: UserType,
-    example: UserType.PROFESSIONAL,
-    description: '사용자 유형 (HOBBY, PROFESSIONAL, ADMIN)',
+    example: UserType.EXPERT,
+    description: '사용자 유형 (HOBBY, EXPERT, ADMIN)',
   })
   @IsEnum(UserType, {
-    message: 'HOBBY, PROFESSIONAL, ADMIN 중에서 선택해야 합니다.',
+    message: 'HOBBY, EXPERT, ADMIN 중에서 선택해야 합니다.',
   })
   @IsOptional()
   userType?: UserType;

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -59,11 +59,11 @@ export class UpdateUserDto {
 
   @ApiPropertyOptional({
     enum: UserType,
-    example: UserType.PROFESSIONAL,
-    description: '사용자 유형 (HOBBY, PROFESSIONAL, ADMIN)',
+    example: UserType.EXPERT,
+    description: '사용자 유형 (HOBBY, EXPERT, ADMIN)',
   })
   @IsEnum(UserType, {
-    message: 'HOBBY, PROFESSIONAL, ADMIN 중에서 선택해야 합니다.',
+    message: 'HOBBY, EXPERT, ADMIN 중에서 선택해야 합니다.',
   })
   @IsOptional()
   userType?: UserType;

--- a/src/users/enums/user-type.enum.ts
+++ b/src/users/enums/user-type.enum.ts
@@ -1,5 +1,5 @@
 export enum UserType {
   HOBBY = 'HOBBY',
-  PROFESSIONAL = 'PROFESSIONAL',
+  EXPERT = 'EXPERT',
   ADMIN = 'ADMIN',
 }


### PR DESCRIPTION
주요 변경사항:
- 게시글 좋아요 상태 API에 인증 가드 추가 (isLiked가 항상 false인 문제 해결)
- 예약 API 응답 구조 표준화 (ApiResponseDto 적용)
- UserType enum PROFESSIONAL -> EXPERT 변경
- 데이터베이스 마이그레이션으로 기존 PROFESSIONAL 데이터를 EXPERT로 안전하게 변환
- TypeORM CLI 설정에 Reservation 엔티티 추가

수정된 파일:
- posts.controller.ts: GET /posts/{id}/like 엔드포인트에 인증 가드 추가
- posts.service.ts: UserType.PROFESSIONAL -> UserType.EXPERT 변경
- reservations.controller.ts: 모든 메서드에 일관된 ApiResponseDto 래핑 적용
- users/enums/user-type.enum.ts: PROFESSIONAL -> EXPERT 변경
- users/dto/*.ts: 모든 DTO에서 enum 설명 및 예시 업데이트
- 마이그레이션 파일 추가: 기존 DB 데이터 안전하게 변환

🤖 Generated with [Claude Code](https://claude.ai/code)