### PR TITLE
Fix: 프로필 이미지 서빙 및 URL 생성 문제 해결

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -60,7 +60,7 @@ import { NcpmsModule } from './ncpms/ncpms.module';
     }),
 
     ServeStaticModule.forRoot({
-      rootPath: join(__dirname, '..', 'uploads'),
+      rootPath: join(process.cwd(), 'uploads'),
       serveRoot: '/uploads',
       serveStaticOptions: {
         maxAge: '1d', // 캐시 설정

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -132,7 +132,7 @@ export class UsersController {
     }
 
     const { id } = req.user;
-    const imageUrl = `/uploads/${file.filename}`; // 상대 경로로 저장
+    const imageUrl = `/uploads/profiles/${file.filename}`; // 올바른 경로로 저장
 
     return this.usersService.uploadProfileImage(id, imageUrl);
   }


### PR DESCRIPTION
- ServeStaticModule rootPath를 process.cwd() 기반으로 수정하여 정적 파일 서빙 경로 문제 해결
- 프로필 이미지 업로드 시 올바른 /uploads/profiles/ 경로로 URL 생성하도록 수정
- 프론트엔드에서 프로필 이미지 렌더링 문제 해결

🤖 Generated with [Claude Code](https://claude.ai/code)