### PR TITLE
feat: 강화된 캘린더/일정 관리 시스템 구현

### DIFF
--- a/migrations/1755532587456-AddColorFieldsAndCommonCrop.ts
+++ b/migrations/1755532587456-AddColorFieldsAndCommonCrop.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddColorFieldsAndScheduleType1755532587456 implements MigrationInterface {
+  name = 'AddColorFieldsAndScheduleType1755532587456';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Crop 테이블에 color 필드 추가
+    await queryRunner.query(
+      `ALTER TABLE "crops" ADD COLUMN "color" varchar(7) NOT NULL DEFAULT '#4CAF50'`,
+    );
+
+    // Schedule 테이블 수정
+    await queryRunner.query(
+      `ALTER TABLE "schedules" ADD COLUMN "color" varchar(7)`,
+    );
+
+    // Schedule type enum 생성 및 컬럼 추가
+    await queryRunner.query(
+      `CREATE TYPE "schedules_type_enum" AS ENUM('crop_diary', 'personal')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "schedules" ADD COLUMN "type" "schedules_type_enum" NOT NULL DEFAULT 'crop_diary'`,
+    );
+
+    // crop 컬럼을 nullable로 변경 (개인 일정 지원)
+    await queryRunner.query(
+      `ALTER TABLE "schedules" ALTER COLUMN "crop" DROP NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "schedules" DROP COLUMN "type"`);
+    await queryRunner.query(`DROP TYPE "schedules_type_enum"`);
+    await queryRunner.query(`ALTER TABLE "schedules" DROP COLUMN "color"`);
+    await queryRunner.query(`ALTER TABLE "crops" DROP COLUMN "color"`);
+    await queryRunner.query(`ALTER TABLE "schedules" ALTER COLUMN "crop" SET NOT NULL`);
+  }
+}

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -37,7 +37,8 @@ export class CommentsService {
 
     // 댓글 생성
     const comment = this.commentsRepository.create({
-      ...createCommentDto,
+      content: createCommentDto.content,
+      isAnonymous: createCommentDto.isAnonymous ?? false,
       post: { id: postId } as Post,
       user: { id: userId } as User,
     });
@@ -141,17 +142,30 @@ export class CommentsService {
       id: comment.id,
       content: comment.content,
       likeCount: comment.likeCount,
-      user: {
-        id: comment.user.id,
-        email: comment.user.email,
-        nickname: comment.user.nickname,
-        name: comment.user.name,
-        interestCrops: comment.user.interestCrops,
-        profileImage: comment.user.profileImage,
-        userType: comment.user.userType,
-        createdAt: comment.user.createdAt,
-        updatedAt: comment.user.updatedAt,
-      },
+      isAnonymous: comment.isAnonymous,
+      user: comment.isAnonymous
+        ? {
+            id: comment.user.id,
+            email: comment.user.email,
+            nickname: '익명',
+            name: null,
+            interestCrops: null,
+            profileImage: '/uploads/farmer_icon.png', // 기본 프로필 이미지
+            userType: comment.user.userType,
+            createdAt: comment.user.createdAt,
+            updatedAt: comment.user.updatedAt,
+          }
+        : {
+            id: comment.user.id,
+            email: comment.user.email,
+            nickname: comment.user.nickname,
+            name: comment.user.name,
+            interestCrops: comment.user.interestCrops,
+            profileImage: comment.user.profileImage,
+            userType: comment.user.userType,
+            createdAt: comment.user.createdAt,
+            updatedAt: comment.user.updatedAt,
+          },
       createdAt: comment.createdAt,
       updatedAt: comment.updatedAt,
     };

--- a/src/comments/dto/comment-response.dto.ts
+++ b/src/comments/dto/comment-response.dto.ts
@@ -11,11 +11,15 @@ export class CommentResponseDto {
   @ApiProperty({ example: 5, description: '댓글 좋아요 수' })
   likeCount: number;
 
+  @ApiProperty({ example: false, description: '익명 댓글 여부' })
+  isAnonymous: boolean;
+
   @ApiProperty({
     type: UserResponseDto,
-    description: '댓글 작성자 정보',
+    description: '댓글 작성자 정보 (익명인 경우 닉네임만 "익명"으로 표시)',
+    required: false,
   })
-  user: UserResponseDto;
+  user: UserResponseDto | null;
 
   @ApiProperty({ example: '2025-08-12T10:30:00.000Z', description: '댓글 생성일' })
   createdAt: Date;

--- a/src/comments/dto/create-comment.dto.ts
+++ b/src/comments/dto/create-comment.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, MinLength, MaxLength } from 'class-validator';
+import { IsString, MinLength, MaxLength, IsBoolean, IsOptional } from 'class-validator';
 
 export class CreateCommentDto {
   @ApiProperty({
@@ -10,4 +10,13 @@ export class CreateCommentDto {
   @MinLength(1, { message: '댓글 내용은 1자 이상이어야 합니다.' })
   @MaxLength(1000, { message: '댓글 내용은 1000자 이하여야 합니다.' })
   content: string;
+
+  @ApiProperty({
+    example: false,
+    description: '익명 댓글 여부 (기본값: false)',
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean({ message: '익명 여부는 불린 값이어야 합니다.' })
+  isAnonymous?: boolean;
 }

--- a/src/comments/entities/comment.entity.ts
+++ b/src/comments/entities/comment.entity.ts
@@ -22,6 +22,9 @@ export class Comment {
   @Column({ default: 0 })
   likeCount: number;
 
+  @Column({ default: false })
+  isAnonymous: boolean;
+
   @ManyToOne(() => User, (user) => user.comments, { onDelete: 'CASCADE' })
   user: User;
 

--- a/src/crops/entities/crop.entity.ts
+++ b/src/crops/entities/crop.entity.ts
@@ -35,6 +35,12 @@ export class Crop {
   @Column({ type: 'text', nullable: true })
   description?: string;
 
+  @Column({ type: 'boolean', default: false, comment: '공통 캘린더용 작물 여부' })
+  isCommon: boolean;
+
+  @Column({ type: 'varchar', length: 7, default: '#4CAF50', comment: '작물 표시 색상 (HEX)' })
+  color: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/migrations/1692345600000-AddTypeAndColorToSchedules.ts
+++ b/src/migrations/1692345600000-AddTypeAndColorToSchedules.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTypeAndColorToSchedules1692345600000 implements MigrationInterface {
+  name = 'AddTypeAndColorToSchedules1692345600000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Schedule 테이블에 type enum과 color 필드 추가
+    await queryRunner.query(`
+      CREATE TYPE "public"."schedules_type_enum" AS ENUM('crop_diary', 'personal')
+    `);
+    
+    await queryRunner.query(`
+      ALTER TABLE "schedules" 
+      ADD "type" "public"."schedules_type_enum" NOT NULL DEFAULT 'crop_diary'
+    `);
+    
+    await queryRunner.query(`
+      ALTER TABLE "schedules" 
+      ADD "color" varchar(7)
+    `);
+
+    // crop 필드를 nullable로 변경
+    await queryRunner.query(`
+      ALTER TABLE "schedules" 
+      ALTER COLUMN "cropId" DROP NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // 변경사항 되돌리기
+    await queryRunner.query(`
+      ALTER TABLE "schedules" 
+      ALTER COLUMN "cropId" SET NOT NULL
+    `);
+    
+    await queryRunner.query(`
+      ALTER TABLE "schedules" 
+      DROP COLUMN "color"
+    `);
+    
+    await queryRunner.query(`
+      ALTER TABLE "schedules" 
+      DROP COLUMN "type"
+    `);
+    
+    await queryRunner.query(`
+      DROP TYPE "public"."schedules_type_enum"
+    `);
+  }
+}

--- a/src/schedules/dto/create-schedule.dto.ts
+++ b/src/schedules/dto/create-schedule.dto.ts
@@ -4,9 +4,12 @@ import {
   IsOptional,
   IsDateString,
   IsNumber,
+  IsEnum,
   MaxLength,
   MinLength,
+  Matches,
 } from 'class-validator';
+import { ScheduleType } from '../entities/schedule.entity';
 
 export class CreateScheduleDto {
   @ApiProperty({
@@ -40,11 +43,35 @@ export class CreateScheduleDto {
   date: string;
 
   @ApiProperty({
+    enum: ScheduleType,
+    example: ScheduleType.CROP_DIARY,
+    description: '일정 유형 (crop_diary: 작물 일지, personal: 개인 일정)',
+    default: ScheduleType.CROP_DIARY,
+  })
+  @IsEnum(ScheduleType, { message: '올바른 일정 유형을 선택해주세요.' })
+  @IsOptional()
+  type?: ScheduleType;
+
+  @ApiProperty({
     example: 1,
-    description: '작물 ID (필수)',
+    description: '작물 ID (개인 일정인 경우 생략 가능)',
+    required: false,
   })
   @IsNumber({}, { message: '작물 ID는 숫자여야 합니다.' })
-  cropId: number;
+  @IsOptional()
+  cropId?: number;
+
+  @ApiProperty({
+    example: '#4CAF50',
+    description: '캘린더 표시 색상 (HEX 코드, 선택사항)',
+    required: false,
+  })
+  @IsOptional()
+  @IsString({ message: '색상은 문자열이어야 합니다.' })
+  @Matches(/^#[0-9A-Fa-f]{6}$/, {
+    message: '올바른 HEX 색상 코드를 입력해주세요. (예: #4CAF50)',
+  })
+  color?: string;
 
   @ApiProperty({
     type: 'string',

--- a/src/schedules/dto/schedule-response.dto.ts
+++ b/src/schedules/dto/schedule-response.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UserResponseDto } from '../../users/dto/user-response.dto';
 import { CropResponseDto } from '../../crops/dto/crop-response.dto';
+import { ScheduleType } from '../entities/schedule.entity';
 
 export class ScheduleResponseDto {
   @ApiProperty({
@@ -36,6 +37,20 @@ export class ScheduleResponseDto {
   image: string | null;
 
   @ApiProperty({
+    example: '#4CAF50',
+    description: '캘린더 표시 색상 (HEX 코드)',
+    nullable: true,
+  })
+  color: string | null;
+
+  @ApiProperty({
+    enum: ScheduleType,
+    example: ScheduleType.CROP_DIARY,
+    description: '일정 유형 (crop_diary: 작물 일지, personal: 개인 일정)',
+  })
+  type: ScheduleType;
+
+  @ApiProperty({
     type: UserResponseDto,
     description: '일정 소유자 정보',
   })
@@ -43,9 +58,10 @@ export class ScheduleResponseDto {
 
   @ApiProperty({
     type: CropResponseDto,
-    description: '관련 작물 정보',
+    description: '관련 작물 정보 (개인 일정인 경우 null)',
+    nullable: true,
   })
-  crop: CropResponseDto;
+  crop: CropResponseDto | null;
 
   @ApiProperty({
     example: '2025-08-12T09:30:00.000Z',

--- a/src/schedules/dto/update-color.dto.ts
+++ b/src/schedules/dto/update-color.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, Matches } from 'class-validator';
+
+export class UpdateColorDto {
+  @ApiProperty({
+    example: '#4CAF50',
+    description: '캘린더 표시 색상 (HEX 코드)',
+  })
+  @IsString({ message: '색상은 문자열이어야 합니다.' })
+  @Matches(/^#[0-9A-Fa-f]{6}$/, {
+    message: '올바른 HEX 색상 코드를 입력해주세요. (예: #4CAF50)',
+  })
+  color: string;
+}

--- a/src/schedules/entities/schedule.entity.ts
+++ b/src/schedules/entities/schedule.entity.ts
@@ -10,6 +10,11 @@ import {
   Index,
 } from 'typeorm';
 
+export enum ScheduleType {
+  CROP_DIARY = 'crop_diary',
+  PERSONAL = 'personal',
+}
+
 @Entity({ name: 'schedules' })
 @Index(['user', 'date']) // 사용자별 날짜 검색 최적화
 export class Schedule {
@@ -28,15 +33,31 @@ export class Schedule {
   @Column({ type: 'varchar', nullable: true, comment: '첨부 이미지 경로' })
   image: string | null;
 
+  @Column({
+    type: 'varchar',
+    length: 7,
+    nullable: true,
+    comment: '캘린더 표시 색상 (HEX)',
+  })
+  color: string | null;
+
+  @Column({
+    type: 'enum',
+    enum: ScheduleType,
+    default: ScheduleType.CROP_DIARY,
+    comment: '일정 유형 (작물 일지 또는 개인 일정)',
+  })
+  type: ScheduleType;
+
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
   user: User;
 
   @ManyToOne(() => Crop, {
     onDelete: 'CASCADE',
-    nullable: false,
+    nullable: true, // 개인 일정은 null 가능
     eager: false,
   })
-  crop: Crop;
+  crop: Crop | null;
 
   @CreateDateColumn()
   createdAt: Date;


### PR DESCRIPTION
- Schedule 엔티티에 type(개인일정/작물일지) 및 color 필드 추가
- 개인 일정 지원을 위한 crop 필드 nullable 처리
- 메인 캘린더 API (개인 일정 + 모든 작물 일지 통합)
- 작물별 캘린더 API 구현
- 일정 색상 커스터마이징 기능
- 익명 댓글 기능 추가
- 모든 API 문서 업데이트 및 타입 안전성 개선