### PR TITLE
Fix: 예약 시스템 500 에러 해결 및 API 문서화 개선

### DIFF
--- a/src/common/decorators/get-user.decorator.ts
+++ b/src/common/decorators/get-user.decorator.ts
@@ -3,6 +3,7 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 interface UserPayload {
   id: number;
   email: string;
+  userType: string;
 }
 
 interface AuthenticatedRequest {

--- a/src/posts/dto/post-response.dto.ts
+++ b/src/posts/dto/post-response.dto.ts
@@ -52,8 +52,9 @@ export class PostResponseDto {
   @ApiProperty({
     type: UserResponseDto,
     description: '게시글 작성자 정보',
+    nullable: true,
   })
-  user: UserResponseDto;
+  user: UserResponseDto | null;
 
   @ApiProperty({
     type: [TagResponseDto],
@@ -69,6 +70,46 @@ export class PostResponseDto {
 
   @ApiProperty({ example: false, description: '현재 사용자의 좋아요 여부' })
   isLiked?: boolean;
+
+  @ApiProperty({
+    example: 50000,
+    description: '가격 (예약글인 경우)',
+    required: false,
+  })
+  price?: number;
+
+  @ApiProperty({
+    example: 20,
+    description: '최대 참가자 수 (예약글인 경우)',
+    required: false,
+  })
+  maxParticipants?: number;
+
+  @ApiProperty({
+    example: 5,
+    description: '현재 참가자 수 (예약글인 경우)',
+  })
+  currentParticipants: number;
+
+  @ApiProperty({
+    example: '2025-08-25T19:00:00.000Z',
+    description: '예정 일시 (예약글인 경우)',
+    required: false,
+  })
+  scheduledDate?: Date;
+
+  @ApiProperty({
+    example: '경기도 화성시 농장로 123',
+    description: '장소 (예약글인 경우)',
+    required: false,
+  })
+  location?: string;
+
+  @ApiProperty({
+    example: true,
+    description: '게시글 활성화 상태',
+  })
+  isActive: boolean;
 }
 
 export class PostListResponseDto {

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -371,6 +371,12 @@ export class PostsService {
       viewCount: post.viewCount,
       likeCount: post.likeCount,
       commentCount: post.commentCount,
+      price: post.price ?? undefined,
+      maxParticipants: post.maxParticipants ?? undefined,
+      currentParticipants: post.currentParticipants,
+      scheduledDate: post.scheduledDate ?? undefined,
+      location: post.location ?? undefined,
+      isActive: post.isActive,
       user: {
         id: post.user.id,
         email: post.user.email,

--- a/src/reservations/dto/create-reservation.dto.ts
+++ b/src/reservations/dto/create-reservation.dto.ts
@@ -1,10 +1,21 @@
 import { IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateReservationDto {
+  @ApiProperty({
+    description: '참가 인원 수',
+    minimum: 1,
+    example: 2,
+  })
   @IsNumber()
   @Min(1)
   participantCount: number;
 
+  @ApiProperty({
+    description: '예약 메시지',
+    required: false,
+    example: '체험 참가 신청합니다.',
+  })
   @IsOptional()
   @IsString()
   message?: string;

--- a/src/reservations/dto/reservation-response.dto.ts
+++ b/src/reservations/dto/reservation-response.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ReservationStatus } from '../enums/reservation-status.enum';
+import { UserResponseDto } from '../../users/dto/user-response.dto';
+import { PostResponseDto } from '../../posts/dto/post-response.dto';
+
+export class ReservationResponseDto {
+  @ApiProperty({ example: 1, description: '예약 ID' })
+  id: number;
+
+  @ApiProperty({ example: 2, description: '참가 인원 수' })
+  participantCount: number;
+
+  @ApiProperty({
+    example: ReservationStatus.PENDING,
+    description: '예약 상태',
+    enum: ReservationStatus,
+  })
+  status: ReservationStatus;
+
+  @ApiProperty({
+    example: '가족 단위로 참여하고 싶습니다.',
+    description: '예약 메시지',
+    nullable: true,
+  })
+  message: string | null;
+
+  @ApiProperty({
+    example: '일정 변경으로 참여가 어려워졌습니다.',
+    description: '취소 사유',
+    nullable: true,
+  })
+  cancelReason: string | null;
+
+  @ApiProperty({
+    type: UserResponseDto,
+    description: '예약 신청자 정보',
+  })
+  user: UserResponseDto;
+
+  @ApiProperty({
+    type: PostResponseDto,
+    description: '예약 게시글 정보',
+  })
+  post: PostResponseDto;
+
+  @ApiProperty({
+    example: '2025-08-18T10:30:00.000Z',
+    description: '예약 생성일',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2025-08-18T10:30:00.000Z',
+    description: '예약 수정일',
+  })
+  updatedAt: Date;
+}

--- a/src/reservations/dto/update-reservation-status.dto.ts
+++ b/src/reservations/dto/update-reservation-status.dto.ts
@@ -1,10 +1,22 @@
 import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { ReservationStatus } from '../enums/reservation-status.enum';
 
 export class UpdateReservationStatusDto {
+  @ApiProperty({
+    description: '예약 상태',
+    enum: ReservationStatus,
+    example: ReservationStatus.CONFIRMED,
+    enumName: 'ReservationStatus',
+  })
   @IsEnum(ReservationStatus)
   status: ReservationStatus;
 
+  @ApiProperty({
+    description: '취소 사유 (CANCELLED 상태일 때 필요)',
+    required: false,
+    example: '일정 변경으로 인한 취소',
+  })
   @IsOptional()
   @IsString()
   cancelReason?: string;

--- a/src/reservations/reservations.controller.ts
+++ b/src/reservations/reservations.controller.ts
@@ -18,9 +18,9 @@ import {
 import { ReservationsService } from './reservations.service';
 import { CreateReservationDto } from './dto/create-reservation.dto';
 import { UpdateReservationStatusDto } from './dto/update-reservation-status.dto';
+import { ReservationResponseDto } from './dto/reservation-response.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { GetUser } from '../common/decorators/get-user.decorator';
-import { Reservation } from './entities/reservation.entity';
 
 @ApiTags('4. Reservation - 예약 관리')
 @ApiBearerAuth()
@@ -32,21 +32,24 @@ export class ReservationsController {
   @Post('posts/:postId')
   @ApiOperation({
     summary: '예약 신청',
-    description: '전문농업인의 예약 게시글에 예약을 신청합니다.',
+    description:
+      '전문농업인의 예약 게시글에 예약을 신청합니다. 필수값: participantCount (참가 인원)',
   })
   @ApiParam({
     name: 'postId',
     description: '예약할 게시글 ID',
     example: 1,
+    type: 'number',
   })
   @ApiResponse({
     status: 201,
     description: '예약 신청이 성공적으로 완료되었습니다.',
-    type: Reservation,
+    type: ReservationResponseDto,
   })
   @ApiResponse({
     status: 400,
-    description: '잘못된 요청 데이터 또는 예약 불가',
+    description:
+      '잘못된 요청 데이터 또는 예약 불가 (본인 게시글, 정원 초과, 중복 예약 등)',
   })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
   @ApiResponse({ status: 404, description: '게시글을 찾을 수 없음' })
@@ -54,7 +57,7 @@ export class ReservationsController {
     @Param('postId', ParseIntPipe) postId: number,
     @Body() createReservationDto: CreateReservationDto,
     @GetUser('id') userId: number,
-  ): Promise<Reservation> {
+  ): Promise<ReservationResponseDto> {
     return this.reservationsService.create(
       postId,
       userId,
@@ -70,12 +73,12 @@ export class ReservationsController {
   @ApiResponse({
     status: 200,
     description: '예약 목록 조회 성공',
-    type: [Reservation],
+    type: [ReservationResponseDto],
   })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
   async findMyReservations(
     @GetUser('id') userId: number,
-  ): Promise<Reservation[]> {
+  ): Promise<ReservationResponseDto[]> {
     return this.reservationsService.findMyReservations(userId);
   }
 
@@ -87,12 +90,12 @@ export class ReservationsController {
   @ApiResponse({
     status: 200,
     description: '받은 예약 목록 조회 성공',
-    type: [Reservation],
+    type: [ReservationResponseDto],
   })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
   async findReceivedReservations(
     @GetUser('id') userId: number,
-  ): Promise<Reservation[]> {
+  ): Promise<ReservationResponseDto[]> {
     return this.reservationsService.findReceivedReservations(userId);
   }
 
@@ -100,27 +103,31 @@ export class ReservationsController {
   @ApiOperation({
     summary: '예약 상태 변경',
     description:
-      '예약을 승인하거나 거절합니다. 게시글 작성자 또는 예약자만 가능합니다.',
+      '예약을 승인하거나 거절합니다. 게시글 작성자 또는 예약자만 가능합니다. 필수값: status (CONFIRMED, CANCELLED 등)',
   })
   @ApiParam({
     name: 'id',
     description: '변경할 예약 ID',
     example: 1,
+    type: 'number',
   })
   @ApiResponse({
     status: 200,
     description: '예약 상태 변경 성공',
-    type: Reservation,
+    type: ReservationResponseDto,
   })
-  @ApiResponse({ status: 400, description: '잘못된 요청 데이터' })
+  @ApiResponse({ status: 400, description: '잘못된 요청 데이터 또는 상태값' })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
-  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiResponse({
+    status: 403,
+    description: '권한 없음 (게시글 작성자 또는 예약자만 가능)',
+  })
   @ApiResponse({ status: 404, description: '예약을 찾을 수 없음' })
   async updateStatus(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateReservationStatusDto: UpdateReservationStatusDto,
     @GetUser('id') userId: number,
-  ): Promise<Reservation> {
+  ): Promise<ReservationResponseDto> {
     return this.reservationsService.updateStatus(
       id,
       userId,
@@ -128,30 +135,77 @@ export class ReservationsController {
     );
   }
 
+  @Get(':id')
+  @ApiOperation({
+    summary: '예약 상세 조회',
+    description: '특정 예약의 상세 정보를 조회합니다.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: '조회할 예약 ID',
+    example: 1,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '예약 조회 성공',
+    type: ReservationResponseDto,
+  })
+  @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
+  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiResponse({ status: 404, description: '예약을 찾을 수 없음' })
+  async findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @GetUser('id') userId: number,
+  ): Promise<ReservationResponseDto> {
+    return this.reservationsService.findOne(id, userId);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: '모든 예약 목록 조회 (관리자용)',
+    description: '관리자만 접근 가능한 모든 예약 목록을 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '예약 목록 조회 성공',
+    type: [ReservationResponseDto],
+  })
+  @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
+  @ApiResponse({ status: 403, description: '관리자 권한 필요' })
+  async findAll(
+    @GetUser() user: { userType: string },
+  ): Promise<ReservationResponseDto[]> {
+    return this.reservationsService.findAll(user.userType);
+  }
+
   @Patch(':id/cancel')
   @ApiOperation({
     summary: '예약 취소',
     description:
-      '예약을 취소합니다. 예약자 또는 게시글 작성자가 취소할 수 있습니다.',
+      '예약을 취소합니다. 예약자 또는 게시글 작성자가 취소할 수 있습니다. 선택값: cancelReason (취소 사유)',
   })
   @ApiParam({
     name: 'id',
     description: '취소할 예약 ID',
     example: 1,
+    type: 'number',
   })
   @ApiResponse({
     status: 200,
     description: '예약 취소 성공',
-    type: Reservation,
+    type: ReservationResponseDto,
   })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
-  @ApiResponse({ status: 403, description: '권한 없음' })
+  @ApiResponse({
+    status: 403,
+    description: '권한 없음 (예약자 또는 게시글 작성자만 가능)',
+  })
   @ApiResponse({ status: 404, description: '예약을 찾을 수 없음' })
   async cancel(
     @Param('id', ParseIntPipe) id: number,
     @Body('cancelReason') cancelReason: string,
     @GetUser('id') userId: number,
-  ): Promise<Reservation> {
+  ): Promise<ReservationResponseDto> {
     return this.reservationsService.cancel(id, userId, cancelReason);
   }
 }


### PR DESCRIPTION
- 예약 목록 조회 시 user relation 누락으로 인한 500 에러 해결
- transformToResponseDto에서 null 안전 접근 구현
- Swagger API 문서화 강화 (필수값, 예시값, 상세 설명 추가)
- PostResponseDto의 user 필드를 nullable로 변경
- UserPayload에 userType 필드 추가로 JWT 토큰 호환성 개선
- 관리자 전용 예약 목록 조회 권한 검증 추가