### PR TITLE
refactor: 캘린더 시스템을 작물일지 전용으로 변경

### DIFF
--- a/src/schedules/dto/create-schedule.dto.ts
+++ b/src/schedules/dto/create-schedule.dto.ts
@@ -4,17 +4,15 @@ import {
   IsOptional,
   IsDateString,
   IsNumber,
-  IsEnum,
   MaxLength,
   MinLength,
   Matches,
 } from 'class-validator';
-import { ScheduleType } from '../entities/schedule.entity';
 
 export class CreateScheduleDto {
   @ApiProperty({
     example: '토마토 씨앗 파종',
-    description: '일지 제목 (1~200자)',
+    description: '작물일지 제목 (1~200자)',
   })
   @IsString({ message: '제목은 문자열이어야 합니다.' })
   @MinLength(1, { message: '제목은 1자 이상이어야 합니다.' })
@@ -24,7 +22,7 @@ export class CreateScheduleDto {
   @ApiProperty({
     example:
       '오늘은 토마토 씨앗을 심는 날입니다. 물을 충분히 주고 햇빛이 잘 드는 곳에 배치했습니다.',
-    description: '일지 내용 (선택사항)',
+    description: '작물일지 내용 (선택사항)',
     required: false,
   })
   @IsString({ message: '내용은 문자열이어야 합니다.' })
@@ -34,7 +32,7 @@ export class CreateScheduleDto {
 
   @ApiProperty({
     example: '2025-08-15',
-    description: '일지 작성 날짜 (YYYY-MM-DD 형식)',
+    description: '작물일지 작성 날짜 (YYYY-MM-DD 형식)',
   })
   @IsDateString(
     {},
@@ -43,23 +41,11 @@ export class CreateScheduleDto {
   date: string;
 
   @ApiProperty({
-    enum: ScheduleType,
-    example: ScheduleType.CROP_DIARY,
-    description: '일정 유형 (crop_diary: 작물 일지, personal: 개인 일정)',
-    default: ScheduleType.CROP_DIARY,
-  })
-  @IsEnum(ScheduleType, { message: '올바른 일정 유형을 선택해주세요.' })
-  @IsOptional()
-  type?: ScheduleType;
-
-  @ApiProperty({
     example: 1,
-    description: '작물 ID (개인 일정인 경우 생략 가능)',
-    required: false,
+    description: '작물 ID (필수)',
   })
   @IsNumber({}, { message: '작물 ID는 숫자여야 합니다.' })
-  @IsOptional()
-  cropId?: number;
+  cropId: number;
 
   @ApiProperty({
     example: '#4CAF50',
@@ -76,7 +62,7 @@ export class CreateScheduleDto {
   @ApiProperty({
     type: 'string',
     format: 'binary',
-    description: '일지 이미지 파일 (선택사항)',
+    description: '작물일지 이미지 파일 (선택사항)',
     required: false,
   })
   @IsOptional()

--- a/src/schedules/entities/schedule.entity.ts
+++ b/src/schedules/entities/schedule.entity.ts
@@ -45,7 +45,7 @@ export class Schedule {
     type: 'enum',
     enum: ScheduleType,
     default: ScheduleType.CROP_DIARY,
-    comment: '일정 유형 (작물 일지 또는 개인 일정)',
+    comment: '일정 유형 (현재는 작물 일지만 사용)',
   })
   type: ScheduleType;
 

--- a/src/schedules/schedules.controller.ts
+++ b/src/schedules/schedules.controller.ts
@@ -35,7 +35,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { GetUser } from '../common/decorators/get-user.decorator';
 import { logImageMulterConfig } from '../common/config/multer.config';
 
-@ApiTags('7. Schedule - 일정/작물일지 관리')
+@ApiTags('7. Schedule - 작물일지 관리')
 @ApiBearerAuth()
 @UseGuards(AuthGuard('jwt'))
 @Controller('schedules')
@@ -45,13 +45,13 @@ export class SchedulesController {
   @Post()
   @UseInterceptors(FileInterceptor('image', logImageMulterConfig))
   @ApiOperation({
-    summary: '새 일정/작물일지 생성',
+    summary: '새 작물일지 생성',
     description:
-      '사용자의 새로운 일정 또는 작물일지를 생성합니다. 이미지를 첨부할 수 있습니다.',
+      '사용자의 새로운 작물일지를 생성합니다. 이미지를 첨부할 수 있습니다.',
   })
   @ApiConsumes('multipart/form-data')
   @ApiBody({
-    description: '일정/작물일지 생성 데이터',
+    description: '작물일지 생성 데이터',
     schema: {
       type: 'object',
       properties: {
@@ -61,16 +61,10 @@ export class SchedulesController {
           example: '오늘 토마토 씨앗을 파종했습니다.',
         },
         date: { type: 'string', example: '2025-08-15' },
-        type: {
-          type: 'string',
-          enum: ['crop_diary', 'personal'],
-          example: 'crop_diary',
-          description: '일정 유형 (crop_diary: 작물 일지, personal: 개인 일정)',
-        },
         cropId: {
           type: 'number',
           example: 1,
-          description: '작물 ID (개인 일정인 경우 생략 가능)',
+          description: '작물 ID (필수)',
         },
         color: {
           type: 'string',
@@ -80,15 +74,15 @@ export class SchedulesController {
         image: {
           type: 'string',
           format: 'binary',
-          description: '일지 이미지 파일 (JPEG, PNG, WebP, 최대 5MB)',
+          description: '작물일지 이미지 파일 (JPEG, PNG, WebP, 최대 5MB)',
         },
       },
-      required: ['title', 'date'],
+      required: ['title', 'date', 'cropId'],
     },
   })
   @ApiResponse({
     status: 201,
-    description: '일정/작물일지가 성공적으로 생성되었습니다.',
+    description: '작물일지가 성공적으로 생성되었습니다.',
     type: ScheduleResponseDto,
   })
   @ApiResponse({ status: 400, description: '잘못된 요청 데이터' })
@@ -105,9 +99,9 @@ export class SchedulesController {
 
   @Get()
   @ApiOperation({
-    summary: '일정/작물일지 목록 조회',
+    summary: '작물일지 목록 조회',
     description:
-      '사용자의 모든 일정과 작물일지를 조회합니다. 특정 작물의 일지만 조회할 수도 있습니다.',
+      '사용자의 모든 작물일지를 조회합니다. 특정 작물의 일지만 조회할 수도 있습니다.',
   })
   @ApiQuery({
     name: 'cropId',
@@ -117,7 +111,7 @@ export class SchedulesController {
   })
   @ApiResponse({
     status: 200,
-    description: '일정/작물일지 목록 조회 성공',
+    description: '작물일지 목록 조회 성공',
     type: ScheduleListResponseDto,
   })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
@@ -236,7 +230,7 @@ export class SchedulesController {
     description: '일정/작물일지 조회 성공',
     type: ScheduleResponseDto,
   })
-  @ApiResponse({ status: 404, description: '일정/작물일지를 찾을 수 없음' })
+  @ApiResponse({ status: 404, description: '작물일지를 찾을 수 없음' })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
   async findOne(
     @Param('id', ParseIntPipe) id: number,
@@ -247,13 +241,13 @@ export class SchedulesController {
   @Patch(':id')
   @UseInterceptors(FileInterceptor('image', logImageMulterConfig))
   @ApiOperation({
-    summary: '일정/작물일지 수정',
+    summary: '작물일지 수정',
     description:
-      '기존 일정 또는 작물일지의 정보를 수정합니다. 이미지를 새로 첨부할 수 있습니다.',
+      '기존 작물일지의 정보를 수정합니다. 이미지를 새로 첨부할 수 있습니다.',
   })
   @ApiConsumes('multipart/form-data')
   @ApiBody({
-    description: '일정/작물일지 수정 데이터',
+    description: '작물일지 수정 데이터',
     schema: {
       type: 'object',
       properties: {
@@ -264,23 +258,23 @@ export class SchedulesController {
         image: {
           type: 'string',
           format: 'binary',
-          description: '새 일지 이미지 파일 (JPEG, PNG, WebP, 최대 5MB)',
+          description: '새 작물일지 이미지 파일 (JPEG, PNG, WebP, 최대 5MB)',
         },
       },
     },
   })
   @ApiParam({
     name: 'id',
-    description: '수정할 일정/작물일지의 ID',
+    description: '수정할 작물일지의 ID',
     example: 1,
   })
   @ApiResponse({
     status: 200,
-    description: '일정/작물일지 수정 성공',
+    description: '작물일지 수정 성공',
     type: ScheduleResponseDto,
   })
   @ApiResponse({ status: 400, description: '잘못된 요청 데이터' })
-  @ApiResponse({ status: 404, description: '일정/작물일지를 찾을 수 없음' })
+  @ApiResponse({ status: 404, description: '작물일지를 찾을 수 없음' })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
   async update(
     @Param('id', ParseIntPipe) id: number,
@@ -299,20 +293,20 @@ export class SchedulesController {
 
   @Delete(':id')
   @ApiOperation({
-    summary: '일정/작물일지 삭제',
-    description: '특정 일정 또는 작물일지를 삭제합니다.',
+    summary: '작물일지 삭제',
+    description: '특정 작물일지를 삭제합니다.',
   })
   @ApiParam({
     name: 'id',
-    description: '삭제할 일정/작물일지의 ID',
+    description: '삭제할 작물일지의 ID',
     example: 1,
   })
   @ApiResponse({
     status: 200,
-    description: '일정/작물일지 삭제 성공',
+    description: '작물일지 삭제 성공',
     type: Object,
   })
-  @ApiResponse({ status: 404, description: '일정/작물일지를 찾을 수 없음' })
+  @ApiResponse({ status: 404, description: '작물일지를 찾을 수 없음' })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
   async remove(
     @Param('id', ParseIntPipe) id: number,
@@ -324,9 +318,8 @@ export class SchedulesController {
 
   @Get('main')
   @ApiOperation({
-    summary: '메인 캘린더 조회 (통합)',
-    description:
-      '모든 일정(개인 일정 + 작물 일지)을 통합하여 캘린더 형태로 조회합니다.',
+    summary: '메인 캘린더 조회 (전체 작물일지)',
+    description: '모든 작물일지를 캘린더 형태로 조회합니다.',
   })
   @ApiQuery({
     name: 'year',
@@ -435,12 +428,12 @@ export class SchedulesController {
 
   @Patch(':id/color')
   @ApiOperation({
-    summary: '일정 색상 변경',
-    description: '특정 일정의 캘린더 표시 색상을 변경합니다.',
+    summary: '작물일지 색상 변경',
+    description: '특정 작물일지의 캘린더 표시 색상을 변경합니다.',
   })
   @ApiParam({
     name: 'id',
-    description: '색상을 변경할 일정 ID',
+    description: '색상을 변경할 작물일지 ID',
     example: 1,
   })
   @ApiBody({
@@ -453,7 +446,7 @@ export class SchedulesController {
     type: ScheduleResponseDto,
   })
   @ApiResponse({ status: 400, description: '잘못된 색상 코드' })
-  @ApiResponse({ status: 404, description: '일정을 찾을 수 없음' })
+  @ApiResponse({ status: 404, description: '작물일지를 찾을 수 없음' })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
   async updateColor(
     @Param('id', ParseIntPipe) id: number,

--- a/src/schedules/schedules.service.ts
+++ b/src/schedules/schedules.service.ts
@@ -26,24 +26,17 @@ export class SchedulesService {
     userId: number,
     imageUrl?: string,
   ): Promise<ScheduleResponseDto> {
-    const type = createScheduleDto.type || ScheduleType.CROP_DIARY;
-    let crop: Crop | null = null;
+    if (!createScheduleDto.cropId) {
+      throw new BadRequestException('작물 일지 작성 시 작물 ID는 필수입니다.');
+    }
 
-    // 작물 일지인 경우 작물 ID 필수
-    if (type === ScheduleType.CROP_DIARY) {
-      if (!createScheduleDto.cropId) {
-        throw new BadRequestException(
-          '작물 일지 작성 시 작물 ID는 필수입니다.',
-        );
-      }
-      crop = await this.cropsRepository.findOne({
-        where: { id: createScheduleDto.cropId, user: { id: userId } },
-      });
-      if (!crop) {
-        throw new NotFoundException(
-          `ID ${createScheduleDto.cropId}번 작물을 찾을 수 없습니다.`,
-        );
-      }
+    const crop = await this.cropsRepository.findOne({
+      where: { id: createScheduleDto.cropId, user: { id: userId } },
+    });
+    if (!crop) {
+      throw new NotFoundException(
+        `ID ${createScheduleDto.cropId}번 작물을 찾을 수 없습니다.`,
+      );
     }
 
     const scheduleData = {
@@ -52,7 +45,7 @@ export class SchedulesService {
       date: createScheduleDto.date,
       image: imageUrl || null,
       color: createScheduleDto.color || null,
-      type,
+      type: ScheduleType.CROP_DIARY,
       user: { id: userId } as User,
       crop,
     };


### PR DESCRIPTION
- 개인 일정(personal) 기능 제거, 작물일지(crop_diary)만 지원
- CreateScheduleDto에서 작물 ID를 필수 값으로 변경
- 모든 API 엔드포인트 및 Swagger 문서를 작물일지 전용으로 업데이트
- 추후 확장 가능성을 위해 ScheduleType enum은 유지
- 캘린더는 전체 농작물 일지 조회 및 표시 용도로만 사용